### PR TITLE
Update doorkeeper version specifier to use 2.x

### DIFF
--- a/doorkeeper_assertion_flow.gemspec
+++ b/doorkeeper_assertion_flow.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'railties', '>= 4.0'
-  spec.add_dependency 'doorkeeper', '>= 2.0'
+  spec.add_dependency 'doorkeeper', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10.3'


### PR DESCRIPTION
@creasty 

Apparently doorkeeper_assertion_flow 0.02 is not compatible with the latest doorkeeper. When we tested with doorkeeper gem 4.3.2, we got the following error:

> ArgumentError: wrong number of arguments (given 1, expected 3)

```
[GEM_ROOT]/gems/doorkeeper_assertion_flow-0.0.2/lib/doorkeeper/request/assertion.rb:11 :in `initialize`
 9       attr_accessor :credentials, :resource_owner, :server
10 
11       def initialize(credentials, resource_owner, server)
12         @credentials, @resource_owner, @server = credentials, resource_owner, server
13       end
```

```
[GEM_ROOT]/gems/doorkeeper-4.3.2/lib/doorkeeper/server.rb:16 :in `new`
14     def token_request(strategy)
15       klass = Request.token_strategy strategy
16       klass.new self
17     end
```

We know it was working fine with doorkeeper 2.2.2 (the last release of 2.x).

I suggest to update version specifier to use 2.x doorkeeper. 